### PR TITLE
fix: 로그인 후 토큰 재발급 로직 수정

### DIFF
--- a/src/components/ProductForm/styles.tsx
+++ b/src/components/ProductForm/styles.tsx
@@ -76,6 +76,8 @@ export const InfoDiv = styled.div`
 
 export const InfoContent = styled.span`
   padding-right: 8px;
+  font-size: 10px;
+  font-weight: 400;
 `;
 
 export const PriceDiv = styled.div`
@@ -103,7 +105,6 @@ export const Image = styled.svg`
   background-position: 50% 50%;
   background-size: contain;
 
-  // transform: scale(1);
   transition: transform 0.3s ease-out;
   cursor: pointer;
 

--- a/src/pages/LogIn/index.tsx
+++ b/src/pages/LogIn/index.tsx
@@ -23,34 +23,40 @@ const Login = () => {
 
   const navigate = useNavigate();
 
-  const onChangeEmail = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const emailRegex =
-      /([\w-.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/;
-    const emailCurrent = e.target.value;
-    setLoginInfo((prevState) => ({ ...prevState, email: emailCurrent }));
+  const onChangeEmail = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const emailRegex =
+        /([\w-.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/;
+      const emailCurrent = e.target.value;
+      setLoginInfo((prevState) => ({ ...prevState, email: emailCurrent }));
 
-    if (!emailRegex.test(emailCurrent)) {
-      setEmailMessage('이메일 형식이 아닙니다.');
-      setIsEmail(false);
-    } else {
-      setEmailMessage('');
-      setIsEmail(true);
-    }
-  }, []);
+      if (!emailRegex.test(emailCurrent)) {
+        setEmailMessage('이메일 형식이 아닙니다.');
+        setIsEmail(false);
+      } else {
+        setEmailMessage('');
+        setIsEmail(true);
+      }
+    },
+    [loginInfo],
+  );
 
-  const onChangePassword = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,15}$/;
-    const passwordCurrent = e.target.value;
-    setLoginInfo((prevState) => ({ ...prevState, password: passwordCurrent }));
+  const onChangePassword = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,15}$/;
+      const passwordCurrent = e.target.value;
+      setLoginInfo((prevState) => ({ ...prevState, password: passwordCurrent }));
 
-    if (!passwordRegex.test(passwordCurrent)) {
-      setPasswordMessage('비밀번호 형식이 아닙니다. 영문, 숫자 포함 8~15자로 입력해주세요.');
-      setIsPassword(false);
-    } else {
-      setPasswordMessage('');
-      setIsPassword(true);
-    }
-  }, []);
+      if (!passwordRegex.test(passwordCurrent)) {
+        setPasswordMessage('비밀번호 형식이 아닙니다. 영문, 숫자 포함 8~15자로 입력해주세요.');
+        setIsPassword(false);
+      } else {
+        setPasswordMessage('');
+        setIsPassword(true);
+      }
+    },
+    [loginInfo],
+  );
 
   const loginMutation = useMutation(async (loginInfo: LoginInfo) => {
     const response = await restFetcher({

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -28,7 +28,7 @@ export const getClient = (() => {
 
 // const { VITE_BASE_URL } = import.meta.env;
 const BASE_URL = import.meta.env.DEV ? '/api' : 'test';
-// const BASE_URL = 'http://15.164.213.39:8080/api';
+// const BASE_URL = 'http://techeermarket.ap-northeast-2.elasticbeanstalk.com/api';
 
 export const api = axios.create({
   baseURL: BASE_URL,
@@ -38,8 +38,14 @@ api.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('access-token');
     if (token) {
-      config.headers['Access-Token'] = `${token}`;
-    } else if (!(window.location.pathname === '/login' || window.location.pathname === '/signup')) {
+      config.headers['access-token'] = `${token}`;
+    } else if (
+      !(
+        window.location.pathname === '/login' ||
+        window.location.pathname === '/signup' ||
+        window.location.pathname === '/'
+      )
+    ) {
       // 로그인, 회원가입 페이지에서는 토큰이 없어도 통과
       alert('로그인 후 이용해주세요.');
       window.location.href = '/login';


### PR DESCRIPTION
## 추가한 기능 설명
- access, refresh 토큰 만료 시 로그인 페이지 이동 후 반복적으로 alert 창이 뜨는 오류 수정
- 로그인하지 않은 사용자도 메인 페이지 볼 수 있도록 수정

<br>

## check list

- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?
